### PR TITLE
Pokemon Searching is catching em all

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -500,6 +500,8 @@ const totalPages = computed(() => {
 const paginatedPokemon = computed(() => {
   if (!filteredPokemon.value) return [];
   const start = (currentPage.value - 1) * pageSize.value;
+
+  // const start = 0;
   return filteredPokemon.value.slice(start, start + pageSize.value);
 });
 
@@ -526,6 +528,10 @@ const filteredPokemon = computed(() => {
 
   return filtered;
 });
+
+watch([search, selectedType], () => {
+  currentPage.value = 1
+})
 
 const nextPage = () => {
   if (currentPage.value < totalPages.value) {


### PR DESCRIPTION
#22 

Added watch (useState for me 🤧) on search so its now searching is absolute and not related to your current page. Took me some time to figure it all out my bad.

here is ss of before 

<img width="1506" height="718" alt="Screenshot 2025-10-05 at 10 33 29 AM" src="https://github.com/user-attachments/assets/bf283066-bdc3-4940-bcd2-40de86b274d7" />

and now its more like this

<img width="1506" height="718" alt="Screenshot 2025-10-05 at 10 33 43 AM" src="https://github.com/user-attachments/assets/ac9cc6de-2171-4157-a212-5af515b8640e" />

Sorry for taking this long.
Also whats your fav pokemon...? look at me github profile i have some Poke'mon decore.

